### PR TITLE
fix link to careers page

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
       <div id="main" class="grid-1">
         <div id="logo"><h1>Twitter Open Source</h1></div>
         <h1>Twitter is built on open source software.</h1>
-        <p>Want to help? <a href="https://twitter.com/jobs/engineering">Join the Flock</a></p>
+        <p>Want to help? <a href="https://careers.twitter.com/en.html">Join the Flock</a></p>
         <p>More about <a href="https://engineering.twitter.com/">Twitter Engineering</a></p>
         <p>&nbsp;</p>
         <p><a href="https://brand.twitter.com/">Logos and other goodies</a></p>


### PR DESCRIPTION
Looks like the link to careers page (labelled as `Join the Flock`) is broken. Linking it to the one I found appropriate. Let me know if this needs to be linked to a page with pre-applied filter like this - https://careers.twitter.com/content/careers-twitter/en/jobs-search.html?team=careers-twitter%3Ateam%2Fsoftware-engineering