### PR TITLE
Fix 'view all projects' href

### DIFF
--- a/content/_index.html
+++ b/content/_index.html
@@ -57,7 +57,7 @@ custom_js: index.js
         <div class="Grid-cell left-text u-size5of12 u-after1of12">
             <h1 class="small-title mega-margin">Explore Projects</h1>
             <p class="mega-margin">Twitter has been built on open source since the beginning. Openness is part of our DNA. The projects you see here were born at Twitter, and patches are always welcome!</p>
-            <button onclick="location.href='projects.html'" type="button" class="Button Button--large">View All Projects</button>
+            <button onclick="location.href='projects'" type="button" class="Button Button--large">View All Projects</button>
         </div>
         <div class="Grid-cell explore-projects-blank"></div>
     </div>


### PR DESCRIPTION
The "view all projects" button was landing on a 404 page.