### PR TITLE
Update year-in-review.css spacing of Top 10 repos

### DIFF
--- a/static/css/year-in-review.css
+++ b/static/css/year-in-review.css
@@ -289,6 +289,7 @@ th {
 
 tr.content {
   height: var(--line-height-xjumbo);
+  line-height: 0.9em;
 }
 
 td.num {


### PR DESCRIPTION
For the Top 10 repos, I have added a bit of spacing so that the repo name's do not clutter when the name's text wrap.