### PR TITLE
move the color from `.foot a` to `a.foot-link`

### DIFF
--- a/assets/css/_main.scss
+++ b/assets/css/_main.scss
@@ -91,7 +91,6 @@ nav {
 
 nav, .header, .footer {
   a {
-    color: white;
     text-decoration: none;
 
     &:hover, &:active {
@@ -196,6 +195,7 @@ span.Icon--caretDown {
 }
 
 a.foot-link {
+  color: white;
   display: block;
   line-height: var(--feather-line-height-xlarge);
 }


### PR DESCRIPTION
otherwise the button in the footer is white text on white background (if not visited).

![Bildschirmfoto 2021-10-22 um 14 58 53](https://user-images.githubusercontent.com/2373/138457764-2ece1414-b7e0-4f61-a788-6984d46c23c5.png)


