### PR TITLE
Inline style for project card

### DIFF
--- a/layouts/_default/projects.html
+++ b/layouts/_default/projects.html
@@ -13,7 +13,7 @@
 
 <div class="container all-projects">
     {{ range sort $.Site.Data.projects "pushedAt" "desc" -}}
-    <div class="project-card" id="{{ .nameWithOwner }}">
+    <div class="project-card" id="{{ .nameWithOwner }}" style="border: 1px solid; border-color: aliceblue;">
         <h1 class="project-name small-margin">{{ .name }}</h1>
         <div class="border small-margin"{{ with .primaryLanguage }} style="border-bottom-color:{{ .color }}"{{ end }}></div>
         <div class="project-description xsmall-margin">{{ .descriptionHTML | safeHTML }}</div>


### PR DESCRIPTION
I have added an Alice Blue border to the project-cards which would make them look like they are inside a box. I believe this color goes well with the design and colour of the page and doesn't effect any other functionality. This is the sample image I tried for few individual cards on the browser.
![image](https://user-images.githubusercontent.com/64772267/230577342-85a25728-2d8d-44d7-b4d6-b319bb5b23fb.png)
