### PR TITLE
twemoji website link should be in project-links div instead of projec…

### DIFF
--- a/data/projects.json
+++ b/data/projects.json
@@ -1395,9 +1395,9 @@
     "watchers": 226
   },
   "twitter/twemoji": {
-    "descriptionHTML": "<div>Emoji for everyone. <a href=\"https://twemoji.twitter.com/\" rel=\"nofollow\">https://twemoji.twitter.com/</a></div>",
+    "descriptionHTML": "<div>Emoji for everyone</div>",
     "forkCount": 1883,
-    "homepageUrl": "",
+    "homepageUrl": "https://twemoji.twitter.com/",
     "isPrivate": false,
     "languages": "HTML JavaScript",
     "name": "twemoji",


### PR DESCRIPTION
@willnorris 
in the projects.json file, the anchor tag was there in a div and they have added the Twitter link there. That's why we are seeing that.
I have fixed the issue. Please look into it.