### PR TITLE
Remove broken tweets section

### DIFF
--- a/content/_index.html
+++ b/content/_index.html
@@ -46,20 +46,6 @@ custom_css: index.scss
     </div>
 </div>
 
-<!-- Follow Us @TwitterOSS -->
-
-<div class="grey section" id="follow-us">
-    <div class="container">
-        <div class="center-text" id="open-source-text">
-            <h1 class="small-title mega-margin open-source-title">Follow Us <a target="_blank"
-                    rel="noopener" href="https://twitter.com/TwitterOSS">@TwitterOSS</a></h1>
-        </div>
-        <div id="open-source-timeline" class="timeline-cell">
-            <a class="twitter-timeline" data-height="500" href="https://twitter.com/TwitterOSS?ref_src=twsrc%5Etfw">Tweets by TwitterOSS</a> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-        </div>
-    </div>
-</div>
-
 <!-- Join the Flock -->
 
 <div class="section" id="career">
@@ -68,9 +54,6 @@ custom_css: index.scss
             <h1 class="small-title mega-margin career-title">Join the Flock</h1>
             <p class="mega-margin">We are always on the lookout for innovative and creative individuals who are passionate about building a platform where all voices can be heard.</p>
             <a href="https://careers.twitter.com" class="Button Button--secondary Button--large">View All Careers</a>
-        </div>
-        <div class="timeline-cell">
-            <a class="twitter-timeline" data-height="500" href="https://twitter.com/TwitterCareers?ref_src=twsrc%5Etfw">Tweets by TwitterCareers</a> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
         </div>
     </div>
 </div>


### PR DESCRIPTION
This section seems to be supposed to show tweets but it doesn't work (anymore). This maybe because of the API changes but even if it would work, the account TwitterOSS probably won't be used anymore in the future as Twitter rebranded to X.

Before:
![image](https://github.com/twitter/opensource-website/assets/94064167/7a681de4-7afa-4178-b25d-b27c1a31b81c)

After:
![image](https://github.com/twitter/opensource-website/assets/94064167/7c75a285-e6cc-41b4-83bc-858eb80bbe8b)
