### PR TITLE
Change the copyright name on the footer (Twitter, Inc -> X Corp.)

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -31,7 +31,7 @@
             </div>
 
             <div class="footer-cell">
-                © {{ now.Format "2006"}} Twitter, Inc.
+                © {{ now.Format "2006"}} X Corp.
             </div>
 
             <div class="footer-cell">


### PR DESCRIPTION
This is a simple pull request that changes the copyright holders' name on the footer to `X Corp.` rather than `Twitter, Inc.`.

![image](https://github.com/user-attachments/assets/f5d3629d-1139-4b8d-a48a-3594e690bc4c)
