### PR TITLE
fix: Move twemoji website link from description to homepageUrl (#165)

### DIFF
--- a/data/projects.json
+++ b/data/projects.json
@@ -1412,9 +1412,9 @@
     "watchers": 222
   },
   "twitter/twemoji": {
-    "descriptionHTML": "<div>Emoji for everyone. <a href=\"https://twemoji.twitter.com/\" class=\"Link--inTextBlock\" rel=\"nofollow\">https://twemoji.twitter.com/</a></div>",
+    "descriptionHTML": "Emoji for everyone.",
     "forkCount": 1870,
-    "homepageUrl": "",
+    "homepageUrl": "https://twemoji.twitter.com/",
     "isPrivate": false,
     "languages": "HTML JavaScript",
     "name": "twemoji",


### PR DESCRIPTION
Fixes #165

The twemoji project's website link was incorrectly placed in the descriptionHTML field instead of the homepageUrl field. This caused the link to appear in the project description section rather than with other project links.

Changes:
- Removed website link from descriptionHTML
- Added website URL to homepageUrl field