### PR TITLE
Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -30,7 +30,7 @@ jobs:
         run: hugo
 
       - name: deploy
-        uses: peaceiris/actions-gh-pages@bbdfb200618d235585ad98e965f4aafc39b4c501 # v3.7.3
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e  # v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           user_name: twitter-service


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions for improved features, bug fixes, and security updates.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `peaceiris/actions-gh-pages` | [`bbdfb20`](https://github.com/peaceiris/actions-gh-pages/commit/bbdfb200618d235585ad98e965f4aafc39b4c501) | [`4f9cc66`](https://github.com/peaceiris/actions-gh-pages/commit/4f9cc6602d3f66b9c108549d475ec49e8ef4d45e) | [Release](https://github.com/peaceiris/actions-gh-pages/releases/tag/v4) | github-pages.yml |

## Why upgrade?

Keeping GitHub Actions up to date ensures:
- **Security**: Latest security patches and fixes
- **Features**: Access to new functionality and improvements
- **Compatibility**: Better support for current GitHub features
- **Performance**: Optimizations and efficiency improvements

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
