### PR TITLE
fix(a11y): improve color contrast ratios for WCAG AA compliance

### DIFF
--- a/assets/css/_main.scss
+++ b/assets/css/_main.scss
@@ -7,6 +7,8 @@
   --line-height-xjumbo: 2.5rem;
   --font-size-mini-jumbo: 1.6rem;
   --line-height-mini-jumbo: 1.8rem;
+  /* Darker primary blue for improved contrast (white on this yields ≥4.5:1) */
+  --tw-color-blue-primary-dark: #004a8d;
 }
 
 /* Animations */
@@ -77,7 +79,7 @@ main {
 
 // common styles across nav, header, and footer
 nav, .header, .footer {
-  background-color: var(--tw-color-blue-primary);
+  background-color: var(--tw-color-blue-primary-dark);
   color: white;
 
   @media (prefers-color-scheme: dark) {
@@ -123,6 +125,8 @@ nav {
 
 .home-link {
   font-weight: var(--feather-font-weight-bold);
+  // bump up to ≥18 pt bold so that 3.0:1 white-on-blue meets WCAG Large-text contrast
+  font-size: var(--font-size-mini-jumbo);
 }
 
 #nav-menu {

--- a/assets/css/index.scss
+++ b/assets/css/index.scss
@@ -22,6 +22,15 @@
   height: 500px;
 }
 
+// ensure sufficient contrast on the Twitter embed link
+// target the <a> bearing the .twitter-timeline class itself,
+// plus any nested anchors under .twitter-timeline or .timeline-cell
+.twitter-timeline,
+.twitter-timeline a,
+.timeline-cell a {
+  color: var(--tw-color-blue-primary-dark) !important;
+}
+
 
 @media (min-width: 600px) {
   #follow-us .container {


### PR DESCRIPTION
---

## Changelog
Fixed multiple color contrast violations detected by [IBM Equal Access Accessibility Checker]((https://github.com/IBMa/equal-access)) to meet WCAG AA requirements:

- Introduced `--tw-color-blue-primary-dark` (#004a8d) for improved contrast ratio (≥4.5:1 for white text)
- Applied darker blue background to nav, header, and footer elements
- Increased font size of `.home-link` to meet large text contrast requirements (≥3.0:1)
- Updated Twitter timeline embed link colors to use the darker blue for sufficient contrast

This resolves 20 accessibility violations related to text contrast ratios across the homepage.

---

## Screenshots
**Before**: 
Multiple WCAG AA contrast violations on light blue (#1DA1F2) background - contrast ratio ~3.0:1 with white text

<img width="2560" height="831" alt="image" src="https://github.com/user-attachments/assets/e813eea8-7c72-4fdb-a3f0-a623e36e47d0" />


**After**: 
All text elements now meet WCAG AA requirements with darker blue (#004a8d) background - contrast ratio ≥4.5:1 for normal text, ≥3.0:1 for large text

<img width="2560" height="833" alt="image" src="https://github.com/user-attachments/assets/b58c8c4a-771b-47e3-a16f-93c70728f391" />

* Note: The patch submitted in this PR was generated by [A11YRepair](https://sites.google.com/view/a11yrepair/home), an automated Web Accessibility repair tool that I developed to address common accessibility violations in web applications. The generated fixes were manually reviewed and validated before submission.

